### PR TITLE
Fix documentation links in main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,6 @@ The same configuration can be used by a "***Documentation Generator***" to creat
 
 | Name                           | Description                    | Documentation                               |
 |--------------------------------|--------------------------------|---------------------------------------------|
-| [documentation](documentation) | Documentation generator        | [Documentation](../documentation/README.md) |
-| [kubernetes](kubernetes)       | Kubernetes resources generator | [Documentation](../kubernetes/README.md)    |
-| [terraform](terraform)         | Terraform generator            | [Documentation](../terraform/README.md)     |
+| [documentation](documentation) | Documentation generator        | [Documentation](documentation/README.md) |
+| [kubernetes](kubernetes)       | Kubernetes resources generator | [Documentation](kubernetes/README.md)    |
+| [terraform](terraform)         | Terraform generator            |      |


### PR DESCRIPTION
* Fix the links so they point at the right directories.
* Remove Terraform documentation link as there is none.